### PR TITLE
Add shop relic filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
                         <phase>package</phase>
                         <configuration>
                             <target>
-                                <copy file="target/FilterTheSpire.jar" tofile="C:/Program Files (x86)/Steam/steamapps/common/SlayTheSpire/mods/FilterTheSpire.jar"/>
+                                <copy file="target/FilterTheSpire.jar" tofile="/home/casey/.steam/steam/steamapps/common/SlayTheSpire/mods/FilterTheSpire.jar"/>
                             </target>
                         </configuration>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
                         <phase>package</phase>
                         <configuration>
                             <target>
-                                <copy file="target/FilterTheSpire.jar" tofile="/home/casey/.steam/steam/steamapps/common/SlayTheSpire/mods/FilterTheSpire.jar"/>
+                                <copy file="target/FilterTheSpire.jar" tofile="C:/Program Files (x86)/Steam/steamapps/common/SlayTheSpire/mods/FilterTheSpire.jar"/>
                             </target>
                         </configuration>
                         <goals>

--- a/src/main/java/FilterTheSpire/FilterManager.java
+++ b/src/main/java/FilterTheSpire/FilterManager.java
@@ -109,6 +109,23 @@ public class FilterManager {
 
     // --------------------------------------------------------------------------------
 
+    public static void setFirstShopRelicIs(String relic) {
+        NthShopRelicFilter filter = new NthShopRelicFilter(relic);
+        setValidatorFromString("shopRelicIs", filter);
+    }
+
+    public static void setShopFiltersFromValidList(ArrayList<String> relicIDs) {
+        ArrayList<AbstractFilter> filtersToCheck = new ArrayList<>();
+        for (String relicID : relicIDs) {
+            NthShopRelicFilter filter = new NthShopRelicFilter(relicID);
+            filtersToCheck.add(filter);
+        }
+
+        setORValidator("shopRelicIsOneOf", filtersToCheck);
+    }
+
+    // --------------------------------------------------------------------------------
+
     public static void print() {
         System.out.println("FilterManager has " + filters.size() + " filters");
     }

--- a/src/main/java/FilterTheSpire/filters/NthShopRelicFilter.java
+++ b/src/main/java/FilterTheSpire/filters/NthShopRelicFilter.java
@@ -1,0 +1,20 @@
+package FilterTheSpire.filters;
+
+import FilterTheSpire.simulators.ShopRelicRngSimulator;
+
+public class NthShopRelicFilter extends AbstractFilter {
+    private String shopRelicName;
+    private int encounterIndex;
+    private ShopRelicRngSimulator shopRelicRngSimulator;
+
+    public NthShopRelicFilter(String shopRelicName) {
+        this.shopRelicName = shopRelicName;
+        this.encounterIndex = 0; // Get the first shop relic if no index is specified.
+        shopRelicRngSimulator = new ShopRelicRngSimulator();
+    }
+
+    public boolean isSeedValid(long seed) {
+        shopRelicRngSimulator.rerollRelics(seed);
+        return shopRelicRngSimulator.nthShopRelic(encounterIndex).equals(shopRelicName);
+    }
+}

--- a/src/main/java/FilterTheSpire/simulators/ShopRelicRngSimulator.java
+++ b/src/main/java/FilterTheSpire/simulators/ShopRelicRngSimulator.java
@@ -1,0 +1,43 @@
+package FilterTheSpire.simulators;
+
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.RelicLibrary;
+import com.megacrit.cardcrawl.random.Random;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class ShopRelicRngSimulator {
+    public ArrayList<String> shopRelicPool = new ArrayList<>();
+
+    private Random relicRng;
+
+    public String nthShopRelic(int n) {
+        return shopRelicPool.get(n);
+    }
+
+    public void rerollRelics(long seed) {
+        relicRng = new Random(seed);
+        this.shopRelicPool = new ArrayList<>();
+
+        // Skip past all these
+        relicRng.randomLong(); // uncommon
+        relicRng.randomLong(); // rare
+        relicRng.randomLong(); // common
+        // relicRng.randomLong(); // shop <- this is the one needed (we perform it below)
+        // this.relicRng.randomLong(); // boss
+
+        generateShopRelics();
+    }
+
+    private void generateShopRelics() {
+        RelicLibrary.populateRelicPool(
+                this.shopRelicPool,
+                AbstractRelic.RelicTier.SHOP,
+                AbstractDungeon.player.chosenClass
+        );
+        Collections.shuffle(this.shopRelicPool, new java.util.Random(relicRng.randomLong()));
+        Collections.reverse(shopRelicPool); // Shop relics are done in reverse order
+    }
+}

--- a/src/main/java/FilterTheSpire/ui/screens/IRelicFilterScreen.java
+++ b/src/main/java/FilterTheSpire/ui/screens/IRelicFilterScreen.java
@@ -1,0 +1,9 @@
+package FilterTheSpire.ui.screens;
+
+public interface IRelicFilterScreen {
+    void selectAll();
+    void invertAll();
+    void refreshFilters();
+    void clearAll();
+    void selectOnly(String relicID);
+}

--- a/src/main/java/FilterTheSpire/ui/screens/RelicUIObject.java
+++ b/src/main/java/FilterTheSpire/ui/screens/RelicUIObject.java
@@ -1,0 +1,129 @@
+package FilterTheSpire.ui.screens;
+
+import FilterTheSpire.utils.ExtraColors;
+import FilterTheSpire.utils.KeyHelper;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.helpers.input.InputHelper;
+
+public class RelicUIObject {
+    private int size = 100;
+    private int hbSize = 75;
+    private int hbOffset = 50;
+
+    private Hitbox hb;
+
+    public String relicID;
+    private float x, y;
+    private Texture tex;
+    private static final Texture TEX_SELECTED_BG = new Texture("FilterTheSpire/images/relic_bg.png");
+
+    public boolean isEnabled = false;
+    private IRelicFilterScreen parent;
+
+    public RelicUIObject(IRelicFilterScreen parent, String relicID, float x, float y) {
+        this.relicID = relicID;
+        this.tex = ImageMaster.getRelicImg(relicID);
+        this.x = x;
+        this.y = y;
+        this.parent = parent;
+
+        hb = new Hitbox(hbSize * Settings.scale, hbSize * Settings.scale);
+    }
+
+    public void enableHitbox() {
+        // Need to adjust them (hb are centered) -- this random guess is probably totally off
+        hb.move((x + hbOffset) * Settings.scale, (y + hbOffset) * Settings.scale);
+    }
+
+    public void disableHitbox() {
+        hb.move(-10000.0f, -10000.0f);
+    }
+
+    public void render(SpriteBatch sb) {
+        // Grow a bit larger when hovered
+        float s = (hb.hovered) ? size * 1.10f : size;
+
+        if (isEnabled) {
+            sb.setColor(ExtraColors.SEL_RELIC_BG);
+            sb.draw(TEX_SELECTED_BG, x * Settings.scale, y * Settings.scale, s * Settings.scale, s * Settings.scale);
+
+            sb.setColor(Color.WHITE);
+        } else {
+            sb.setColor(ExtraColors.DIM_RELIC);
+        }
+
+
+        sb.draw(tex, x * Settings.scale, y * Settings.scale, s * Settings.scale, s * Settings.scale);
+
+        // DEBUG
+        hb.render(sb);
+    }
+
+    private void handleClick() {
+        if (KeyHelper.isShiftPressed()) {
+            CardCrawlGame.sound.play("BLOOD_SPLAT");
+            parent.selectAll();
+        }
+        else if (KeyHelper.isAltPressed()) {
+            CardCrawlGame.sound.play("MAP_SELECT_3");
+            parent.invertAll();
+        }
+        else {
+            if (isEnabled) CardCrawlGame.sound.playA("UI_CLICK_1", 0.2f);
+            else CardCrawlGame.sound.playA("UI_CLICK_1", -0.4f);
+
+            isEnabled = !isEnabled;
+            parent.refreshFilters();
+        }
+    }
+
+    private void handleRightClick() {
+        if (KeyHelper.isShiftPressed()) {
+            CardCrawlGame.sound.play("APPEAR");
+            parent.clearAll();
+        }
+        else {
+            CardCrawlGame.sound.play("KEY_OBTAIN");
+            parent.selectOnly(relicID);
+        }
+    }
+
+    private boolean mouseDownRight = false;
+
+    public void update() {
+        hb.update();
+
+        if (hb.justHovered) {
+            CardCrawlGame.sound.playAV("UI_HOVER", -0.4f, 0.5f);
+        }
+
+        // Right clicks
+        if (hb.hovered && InputHelper.isMouseDown_R) {
+            mouseDownRight = true;
+        } else {
+            // We already had the mouse down, and now we released, so fire our right click event
+            if (hb.hovered && mouseDownRight) {
+                handleRightClick();
+                mouseDownRight = false;
+            }
+        }
+
+        // Left clicks
+        if (this.hb.hovered && InputHelper.justClickedLeft) {
+            this.hb.clickStarted = true;
+        }
+
+        if (hb.clicked) {
+            hb.clicked = false;
+            handleClick();
+        }
+
+    }
+}
+

--- a/src/main/java/FilterTheSpire/ui/screens/ShopRelicFilterScreen.java
+++ b/src/main/java/FilterTheSpire/ui/screens/ShopRelicFilterScreen.java
@@ -14,42 +14,28 @@ import com.megacrit.cardcrawl.relics.AbstractRelic;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.TreeSet;
-import java.util.function.Consumer;
 
 /*
     Shown when the user goes to Main Menu -> Mods -> Filter the Spire -> Config
  */
-public class BossSwapFilterScreen implements IRelicFilterScreen {
-    private TreeSet<String> bossRelics = new TreeSet<>();
+public class ShopRelicFilterScreen implements IRelicFilterScreen {
+
+    private TreeSet<String> shopRelics = new TreeSet<>();
     private HashMap<String, RelicUIObject> relicUIObjects = new HashMap<>();
 
-    public BossSwapFilterScreen() {
+    public ShopRelicFilterScreen() {
         setup();
     }
 
     private void populateRelics() {
         ArrayList<String> relics = new ArrayList<>();
 
-        RelicLibrary.populateRelicPool(relics, AbstractRelic.RelicTier.BOSS, AbstractPlayer.PlayerClass.IRONCLAD);
-        RelicLibrary.populateRelicPool(relics, AbstractRelic.RelicTier.BOSS, AbstractPlayer.PlayerClass.THE_SILENT);
-        RelicLibrary.populateRelicPool(relics, AbstractRelic.RelicTier.BOSS, AbstractPlayer.PlayerClass.DEFECT);
-        RelicLibrary.populateRelicPool(relics, AbstractRelic.RelicTier.BOSS, AbstractPlayer.PlayerClass.WATCHER);
+        RelicLibrary.populateRelicPool(relics, AbstractRelic.RelicTier.SHOP, AbstractPlayer.PlayerClass.IRONCLAD);
+        RelicLibrary.populateRelicPool(relics, AbstractRelic.RelicTier.SHOP, AbstractPlayer.PlayerClass.THE_SILENT);
+        RelicLibrary.populateRelicPool(relics, AbstractRelic.RelicTier.SHOP, AbstractPlayer.PlayerClass.DEFECT);
+        RelicLibrary.populateRelicPool(relics, AbstractRelic.RelicTier.SHOP, AbstractPlayer.PlayerClass.WATCHER);
 
-        bossRelics.addAll(relics);
-        removeClassUpgradedRelics();
-    }
-
-    // Don't allow unswappable relics to enter the pool
-    private void removeClassUpgradedRelics() {
-        Consumer<String> remove = (relicName) -> {
-            if (bossRelics.contains(relicName))
-                bossRelics.remove(relicName);
-        };
-
-        remove.accept("Black Blood");
-        remove.accept("Ring of the Serpent");
-        remove.accept("FrozenCore");
-        remove.accept("HolyWater");
+        shopRelics.addAll(relics);
     }
 
     private void makeUIObjects() {
@@ -63,7 +49,7 @@ public class BossSwapFilterScreen implements IRelicFilterScreen {
         int iy = 0;
         final int perRow = 5;
 
-        for (String id : bossRelics) {
+        for (String id : shopRelics) {
             float tx = left + ix * spacing;
             float ty = top - iy * spacing;
 
@@ -77,7 +63,7 @@ public class BossSwapFilterScreen implements IRelicFilterScreen {
         }
     }
     private void loadFromConfig() {
-        ArrayList<String> loaded = FilterTheSpire.config.getBossSwapFilter();
+        ArrayList<String> loaded = FilterTheSpire.config.getShopRelicFilter();
         for (String relic : loaded) {
             if (relicUIObjects.containsKey(relic))
                 relicUIObjects.get(relic).isEnabled = true;
@@ -101,7 +87,7 @@ public class BossSwapFilterScreen implements IRelicFilterScreen {
         // Title text
         float titleLeft = 386.0f;
         float titleBottom = 819.0f;
-        FontHelper.renderFontLeftDownAligned(sb, ExtraFonts.configTitleFont(), "Neow Boss Swaps", titleLeft * Settings.scale, titleBottom * Settings.scale, Settings.GOLD_COLOR);
+        FontHelper.renderFontLeftDownAligned(sb, ExtraFonts.configTitleFont(), "First Shop Relic", titleLeft * Settings.scale, titleBottom * Settings.scale, Settings.GOLD_COLOR);
 
         float infoLeft = 1120.0f;
         float infoTopMain = 667.0f;
@@ -109,7 +95,7 @@ public class BossSwapFilterScreen implements IRelicFilterScreen {
 
         FontHelper.renderSmartText(sb,
                 FontHelper.tipBodyFont,
-                "This filter allows you to choose which Boss Relics will appear from Neow's swap option. If no relics are selected, it will choose from the entire pool.",
+                "This filter allows you to choose which Shop Relics will appear in the first Shop. If no relics are selected, it will choose from the entire pool.",
                 infoLeft * Settings.scale,
                 infoTopMain * Settings.scale,
                 371.0f * Settings.scale,
@@ -200,7 +186,7 @@ public class BossSwapFilterScreen implements IRelicFilterScreen {
 
     public void refreshFilters() {
         ArrayList<String> enabledRelics = getEnabledRelics();
-        FilterTheSpire.config.setBossSwapFilter(enabledRelics);
-        FilterManager.setBossSwapFiltersFromValidList(enabledRelics);
+        FilterTheSpire.config.setShopRelicFilter(enabledRelics);
+        FilterManager.setShopFiltersFromValidList(enabledRelics);
     }
 }

--- a/src/main/java/FilterTheSpire/utils/Config.java
+++ b/src/main/java/FilterTheSpire/utils/Config.java
@@ -16,6 +16,7 @@ public class Config {
 
     public Config() {
         defaults.put("bossSwapFilter", "[]");
+        defaults.put("shopRelicFilter", "[]");
 
         try {
             spireConfig = new SpireConfig("FilterTheSpire", "config", defaults);
@@ -61,6 +62,11 @@ public class Config {
 
     public void setBossSwapFilter(ArrayList<String> enabledList) { setStringList("bossSwapFilter", enabledList); }
     public ArrayList<String> getBossSwapFilter() { return getStringList("bossSwapFilter"); }
+
+    // --------------------------------------------------------------------------------
+
+    public void setShopRelicFilter(ArrayList<String> enabledList) { setStringList("shopRelicFilter", enabledList); }
+    public ArrayList<String> getShopRelicFilter() { return getStringList("shopRelicFilter"); }
 
     // --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit adds the Shop relic option for those who want an early Prismatic shard, Membership Card, or Orange Pellets in the first shop.

This filter works by itself, but I did not test it in conjunction with the Boss Swap, because theoretically you should be able to have both Filters on. I did not test it because I do not know how to really build the menu in such a way where it can toggle between Boss Swap menu and Shop relic menu.

Merging this as is should not change the functionality of the mod at the moment, since it's not being used from the menu until another commit is made to add it. Feel free to share the code between BossSwapFilterScreen and ShopRelicFilterScreen, there are very few differences between them.