### PR TITLE
fix RNG order in Nth relic filter

### DIFF
--- a/src/main/java/FilterTheSpire/FilterManager.java
+++ b/src/main/java/FilterTheSpire/FilterManager.java
@@ -3,9 +3,7 @@ package FilterTheSpire;
 import FilterTheSpire.filters.*;
 import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.*;
 
 @SpireInitializer
 public class FilterManager {
@@ -15,10 +13,17 @@ public class FilterManager {
     public static void initialize() { getInstance(); }
 
     private static HashMap<String, AbstractFilter> filters = new HashMap<>();
+    private static List<AbstractFilter> sortedList = null;
 
     // Returns true if all filters pass for the given seed
     public static boolean validateFilters(long seed) {
-        return filters.values().stream().allMatch(v -> v.isSeedValid(seed));
+        return sortedList.stream().allMatch(v -> v.isSeedValid(seed));
+    }
+
+    // Sort the filters so we short circuit on the least intensive filters first
+    public static void sortFilters(){
+        sortedList = new ArrayList<>(filters.values());
+        sortedList.sort(Comparator.comparingInt(AbstractFilter::getSortOrder));
     }
 
     public static boolean hasFilters() {
@@ -111,8 +116,16 @@ public class FilterManager {
     // --------------------------------------------------------------------------------
 
     public static void setNthRelicFromValidList(ArrayList<String> relicIds) {
-        NeowRelicFilter filter = new NeowRelicFilter(relicIds);
-        filters.put("nthRelicIsOneOf", filter);
+        setNthRelicFromValidList(relicIds, 0);
+    }
+
+    public static void setNthRelicFromValidList(ArrayList<String> relicIds, int encounterIndex) {
+        if (relicIds.size() > 0) {
+            NeowRelicFilter filter = new NeowRelicFilter(relicIds, encounterIndex);
+            filters.put("nthRelicIsOneOf" + encounterIndex, filter);
+        } else {
+            filters.remove("nthRelicIsOneOf" + encounterIndex);
+        }
     }
 
     // --------------------------------------------------------------------------------

--- a/src/main/java/FilterTheSpire/filters/AbstractFilter.java
+++ b/src/main/java/FilterTheSpire/filters/AbstractFilter.java
@@ -1,5 +1,9 @@
 package FilterTheSpire.filters;
 
 public abstract class AbstractFilter {
+    protected int sortOrder = 0;
+    public int getSortOrder() {
+        return sortOrder;
+    }
     public abstract boolean isSeedValid(long seed);
 }

--- a/src/main/java/FilterTheSpire/filters/NeowRelicFilter.java
+++ b/src/main/java/FilterTheSpire/filters/NeowRelicFilter.java
@@ -8,9 +8,9 @@ public class NeowRelicFilter extends AbstractFilter {
     private List<String> relicNames;
     private int encounterIndex;
 
-    public NeowRelicFilter(List<String> relicNames) {
+    public NeowRelicFilter(List<String> relicNames, int encounterIndex) {
         this.relicNames = relicNames;
-        this.encounterIndex = 0; // Get the first Relic
+        this.encounterIndex = encounterIndex;
     }
 
     public boolean isSeedValid(long seed) {

--- a/src/main/java/FilterTheSpire/filters/NthBossRelicFilter.java
+++ b/src/main/java/FilterTheSpire/filters/NthBossRelicFilter.java
@@ -3,7 +3,6 @@ package FilterTheSpire.filters;
 import FilterTheSpire.simulators.RelicRngSimulator;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class NthBossRelicFilter extends AbstractFilter{
@@ -21,7 +20,7 @@ public class NthBossRelicFilter extends AbstractFilter{
     }
 
     public boolean isSeedValid(long seed) {
-        List<String> seedBossRelics = RelicRngSimulator.getInstance().getRelicPool(seed, AbstractRelic.RelicTier.BOSS, RelicRngSimulator.BossRelicRng);
+        List<String> seedBossRelics = RelicRngSimulator.getInstance().getRelicPools(seed, AbstractRelic.RelicTier.BOSS);
         return bossRelicNames.contains(seedBossRelics.get(this.encounterIndex));
     }
 }

--- a/src/main/java/FilterTheSpire/filters/NthShopRelicFilter.java
+++ b/src/main/java/FilterTheSpire/filters/NthShopRelicFilter.java
@@ -16,7 +16,7 @@ public class NthShopRelicFilter extends AbstractFilter {
     }
 
     public boolean isSeedValid(long seed) {
-        List<String> shopRelicPool = RelicRngSimulator.getInstance().getRelicPool(seed, AbstractRelic.RelicTier.SHOP, RelicRngSimulator.ShopRelicRng);
+        List<String> shopRelicPool = RelicRngSimulator.getInstance().getRelicPools(seed, AbstractRelic.RelicTier.SHOP);
         Collections.reverse(shopRelicPool); // Shop relics are done in reverse order
         return shopRelicNames.contains(shopRelicPool.get(this.encounterIndex));
     }

--- a/src/main/java/FilterTheSpire/filters/PandorasCardFilter.java
+++ b/src/main/java/FilterTheSpire/filters/PandorasCardFilter.java
@@ -6,13 +6,12 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 
 import java.util.HashMap;
 
-// This is different than other filters in that it's not taking in a List<String>
-// We could always take in a List<String> for the cards and just make them a Hashmap in the constructor here
 public class PandorasCardFilter extends AbstractFilter {
     private HashMap<String, Integer> searchCards;
     private int pandoraTransforms;
 
     public PandorasCardFilter(HashMap<String, Integer> searchCards){
+        this.sortOrder = 1;
         this.searchCards = searchCards;
         this.pandoraTransforms = AbstractDungeon.player.getStartingDeck().size() -
                 ((AbstractDungeon.player.chosenClass == AbstractPlayer.PlayerClass.IRONCLAD) ? 1 : 2);

--- a/src/main/java/FilterTheSpire/multithreading/SeedSearcherThread.java
+++ b/src/main/java/FilterTheSpire/multithreading/SeedSearcherThread.java
@@ -26,6 +26,8 @@ public class SeedSearcherThread extends Thread {
 
     @Override
     public void run() {
+        FilterManager.sortFilters();
+
         while(parent.isRunning()) {
             ++seedsExamined;
 


### PR DESCRIPTION
Fixed some stuff with the Nth relic filter, may not be perfect with how treasure chests limit rarity, but it at least works more often than it did.

Tested finding Unceasing Top as first relic, then Blue Candle as second relic