### PR TITLE
Fix neow card transforms

### DIFF
--- a/src/main/java/FilterTheSpire/FilterManager.java
+++ b/src/main/java/FilterTheSpire/FilterManager.java
@@ -101,6 +101,10 @@ public class FilterManager {
         filters.put("pandorasTmp", new PandorasCardFilter(searchCards));
     }
 
+    public static void setAstrolabeCardFilter(HashMap<String, Integer> searchCards) {
+        filters.put("astrolabeFilter", new AstrolabeCardFilter(searchCards));
+    }
+
     // --------------------------------------------------------------------------------
 
     public static void setFirstShopRelicIs(String relic) {

--- a/src/main/java/FilterTheSpire/FilterTheSpire.java
+++ b/src/main/java/FilterTheSpire/FilterTheSpire.java
@@ -74,11 +74,14 @@ public class FilterTheSpire implements PostInitializeSubscriber, PostDungeonInit
     @Override
     public void receivePostDungeonInitialize() {
 //        HashMap<String, Integer> cards = new HashMap<>();
-//        cards.put("Blade Dance", 4);
+//        cards.put("Tantrum", 1);
 //        cards.put("Accuracy", 1);
 //        FilterManager.setPandorasCardFilter(cards);
-//        FilterManager.setValidatorFromString("blessingFilter", new BlessingFilter(NeowReward.NeowRewardType.ONE_RARE_RELIC, NeowReward.NeowRewardDrawback.TEN_PERCENT_HP_LOSS));
-//        FilterManager.setValidatorFromString("blessingFilter", new BlessingFilter(NeowReward.NeowRewardType.TRANSFORM_CARD, "Prepared"));
+//        FilterManager.setValidatorFromString(
+//                "blessingFilter2",
+//                new BlessingFilter(NeowReward.NeowRewardType.TRANSFORM_TWO_CARDS, cards, NeowReward.NeowRewardDrawback.TEN_PERCENT_HP_LOSS)
+//        );
+//        FilterManager.setValidatorFromString("blessingFilter1", new BlessingFilter(NeowReward.NeowRewardType.TRANSFORM_CARD, cards));
 //        FilterManager.setValidatorFromString("blessingFilter", new BlessingFilter(NeowReward.NeowRewardType.ONE_RANDOM_RARE_CARD, "Glass Knife"));
 
         if (!FilterManager.hasFilters()) {

--- a/src/main/java/FilterTheSpire/FilterTheSpire.java
+++ b/src/main/java/FilterTheSpire/FilterTheSpire.java
@@ -74,9 +74,10 @@ public class FilterTheSpire implements PostInitializeSubscriber, PostDungeonInit
     @Override
     public void receivePostDungeonInitialize() {
 //        HashMap<String, Integer> cards = new HashMap<>();
-//        cards.put("Tantrum", 1);
+//        cards.put("Apotheosis", 1);
 //        cards.put("Accuracy", 1);
 //        FilterManager.setPandorasCardFilter(cards);
+//        FilterManager.setAstrolabeCardFilter(cards);
 //        FilterManager.setValidatorFromString(
 //                "blessingFilter2",
 //                new BlessingFilter(NeowReward.NeowRewardType.TRANSFORM_TWO_CARDS, cards, NeowReward.NeowRewardDrawback.TEN_PERCENT_HP_LOSS)

--- a/src/main/java/FilterTheSpire/factory/CharacterPoolFactory.java
+++ b/src/main/java/FilterTheSpire/factory/CharacterPoolFactory.java
@@ -45,10 +45,11 @@ public class CharacterPoolFactory {
     /**
      * Returns the card pool for the character.
      * @param chosenClass: class of the character pool
-     * @param shouldReverseCardOrder: should be TRUE if the card pool is reversed, seems very rare
+     * @param shouldReverseCommonCardPool: should be TRUE if the common card pool is reversed, seems random when this happens
+     *                                   It's only common card pool that is affected, no other rarities are reversed
      * @return all cards in the chosen Character's pool in a deterministic order
      */
-    public static List<String> getCardPool(AbstractPlayer.PlayerClass chosenClass, boolean shouldReverseCardOrder){
+    public static List<String> getCardPool(AbstractPlayer.PlayerClass chosenClass, boolean shouldReverseCommonCardPool){
         CharacterPool pool;
         ArrayList<String> cardPool = new ArrayList<>();
         if (ModHelper.isModEnabled("Diverse")){
@@ -57,10 +58,10 @@ public class CharacterPoolFactory {
             colors.add(DefectPool.getInstance());
             colors.add(SilentPool.getInstance());
             colors.add(IroncladPool.getInstance());
-            cardPool.addAll(CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder));
+            cardPool.addAll(CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCommonCardPool));
         } else {
             pool = getCharacterPool(chosenClass);
-            cardPool.addAll(pool.getCardPool(shouldReverseCardOrder));
+            cardPool.addAll(pool.getCardPool(shouldReverseCommonCardPool));
         }
         return cardPool;
     }

--- a/src/main/java/FilterTheSpire/factory/CharacterPoolFactory.java
+++ b/src/main/java/FilterTheSpire/factory/CharacterPoolFactory.java
@@ -42,7 +42,13 @@ public class CharacterPoolFactory {
         }
     }
 
-    public static List<String> getCardPool(AbstractPlayer.PlayerClass chosenClass){
+    /**
+     * Returns the card pool for the character.
+     * @param chosenClass: class of the character pool
+     * @param shouldReverseCardOrder: should be TRUE if the card pool is reversed, seems very rare
+     * @return all cards in the chosen Character's pool in a deterministic order
+     */
+    public static List<String> getCardPool(AbstractPlayer.PlayerClass chosenClass, boolean shouldReverseCardOrder){
         CharacterPool pool;
         ArrayList<String> cardPool = new ArrayList<>();
         if (ModHelper.isModEnabled("Diverse")){
@@ -51,10 +57,10 @@ public class CharacterPoolFactory {
             colors.add(DefectPool.getInstance());
             colors.add(SilentPool.getInstance());
             colors.add(IroncladPool.getInstance());
-            cardPool.addAll(CardPoolHelper.getOrderedCardPoolForColors(colors));
+            cardPool.addAll(CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder));
         } else {
             pool = getCharacterPool(chosenClass);
-            cardPool.addAll(pool.getCardPool());
+            cardPool.addAll(pool.getCardPool(shouldReverseCardOrder));
         }
         return cardPool;
     }

--- a/src/main/java/FilterTheSpire/filters/AstrolabeCardFilter.java
+++ b/src/main/java/FilterTheSpire/filters/AstrolabeCardFilter.java
@@ -1,0 +1,24 @@
+package FilterTheSpire.filters;
+
+import FilterTheSpire.simulators.CardTransformSimulator;
+import FilterTheSpire.utils.SeedHelper;
+import com.megacrit.cardcrawl.random.Random;
+
+import java.util.HashMap;
+
+public class AstrolabeCardFilter extends AbstractFilter {
+    private HashMap<String, Integer> searchCards;
+    private int totalTransformCount;
+
+    public AstrolabeCardFilter(HashMap<String, Integer> searchCards){
+        this.sortOrder = 1;
+        this.searchCards = searchCards;
+        this.totalTransformCount = 3;
+    }
+
+    public boolean isSeedValid(long seed) {
+        Random cardRng = SeedHelper.getNewRNG(seed, SeedHelper.RNGType.MISC);
+        cardRng.random();
+        return CardTransformSimulator.getInstance().isValid(cardRng, searchCards, totalTransformCount, false);
+    }
+}

--- a/src/main/java/FilterTheSpire/filters/AstrolabeCardFilter.java
+++ b/src/main/java/FilterTheSpire/filters/AstrolabeCardFilter.java
@@ -19,6 +19,6 @@ public class AstrolabeCardFilter extends AbstractFilter {
     public boolean isSeedValid(long seed) {
         Random cardRng = SeedHelper.getNewRNG(seed, SeedHelper.RNGType.MISC);
         cardRng.random();
-        return CardTransformSimulator.getInstance().isValid(cardRng, searchCards, totalTransformCount, false);
+        return CardTransformSimulator.getInstance().isValid(cardRng, searchCards, totalTransformCount, true);
     }
 }

--- a/src/main/java/FilterTheSpire/filters/PandorasCardFilter.java
+++ b/src/main/java/FilterTheSpire/filters/PandorasCardFilter.java
@@ -1,23 +1,26 @@
 package FilterTheSpire.filters;
 
 import FilterTheSpire.simulators.CardTransformSimulator;
+import FilterTheSpire.utils.SeedHelper;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.random.Random;
 
 import java.util.HashMap;
 
 public class PandorasCardFilter extends AbstractFilter {
     private HashMap<String, Integer> searchCards;
-    private int pandoraTransforms;
+    private int totalTransformCount;
 
     public PandorasCardFilter(HashMap<String, Integer> searchCards){
-        this.sortOrder = 1;
+        this.sortOrder = 2;
         this.searchCards = searchCards;
-        this.pandoraTransforms = AbstractDungeon.player.getStartingDeck().size() -
+        this.totalTransformCount = AbstractDungeon.player.getStartingDeck().size() -
                 ((AbstractDungeon.player.chosenClass == AbstractPlayer.PlayerClass.IRONCLAD) ? 1 : 2);
     }
 
     public boolean isSeedValid(long seed) {
-        return CardTransformSimulator.getInstance().isValid(seed, searchCards, pandoraTransforms);
+        Random cardRng = SeedHelper.getNewRNG(seed, SeedHelper.RNGType.CARDRANDOM);
+        return CardTransformSimulator.getInstance().isValid(cardRng, searchCards, totalTransformCount, false);
     }
 }

--- a/src/main/java/FilterTheSpire/simulators/BlessingSimulator.java
+++ b/src/main/java/FilterTheSpire/simulators/BlessingSimulator.java
@@ -71,7 +71,7 @@ public class BlessingSimulator {
             blessingRng.random(0, 3);
             if (rewardType == NeowReward.NeowRewardType.TRANSFORM_CARD){
                 blessingRng.random();
-                isValid = isValid && CardTransformSimulator.getInstance().isValid(blessingRng, searchCards, 1, shouldReverseCardPoolOrder());
+                isValid = isValid && CardTransformSimulator.getInstance().isValid(blessingRng, searchCards, 1, true);
             } else if (rewardType == NeowReward.NeowRewardType.ONE_RANDOM_RARE_CARD){
                 isValid = isValid && searchCards.containsKey(AbstractDungeon.getCard(AbstractCard.CardRarity.RARE, blessingRng).cardID);
             }
@@ -120,13 +120,8 @@ public class BlessingSimulator {
         }
         if (!searchCards.isEmpty() && rewardType == NeowReward.NeowRewardType.TRANSFORM_TWO_CARDS){
             blessingRng.random();
-            isValid = isValid && CardTransformSimulator.getInstance().isValid(blessingRng, searchCards, 2, shouldReverseCardPoolOrder());
+            isValid = isValid && CardTransformSimulator.getInstance().isValid(blessingRng, searchCards, 2, true);
         }
         return isValid;
-    }
-
-    // Don't ask why this is needed. Silent's card pool is reversed on the Neow Transforms, everyone else's is fine
-    private boolean shouldReverseCardPoolOrder(){
-        return AbstractDungeon.player.chosenClass == AbstractPlayer.PlayerClass.THE_SILENT;
     }
 }

--- a/src/main/java/FilterTheSpire/simulators/BlessingSimulator.java
+++ b/src/main/java/FilterTheSpire/simulators/BlessingSimulator.java
@@ -2,6 +2,7 @@ package FilterTheSpire.simulators;
 
 import FilterTheSpire.utils.SeedHelper;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.neow.NeowReward;
 import com.megacrit.cardcrawl.random.Random;
@@ -69,7 +70,8 @@ public class BlessingSimulator {
             blessingRng.random();
             blessingRng.random(0, 3);
             if (rewardType == NeowReward.NeowRewardType.TRANSFORM_CARD){
-                isValid = isValid && CardTransformSimulator.getInstance().isValid(blessingRng, searchCards, 1);
+                blessingRng.random();
+                isValid = isValid && CardTransformSimulator.getInstance().isValid(blessingRng, searchCards, 1, shouldReverseCardPoolOrder());
             } else if (rewardType == NeowReward.NeowRewardType.ONE_RANDOM_RARE_CARD){
                 isValid = isValid && searchCards.containsKey(AbstractDungeon.getCard(AbstractCard.CardRarity.RARE, blessingRng).cardID);
             }
@@ -118,8 +120,13 @@ public class BlessingSimulator {
         }
         if (!searchCards.isEmpty() && rewardType == NeowReward.NeowRewardType.TRANSFORM_TWO_CARDS){
             blessingRng.random();
-            isValid = isValid && CardTransformSimulator.getInstance().isValid(blessingRng, searchCards, 2);
+            isValid = isValid && CardTransformSimulator.getInstance().isValid(blessingRng, searchCards, 2, shouldReverseCardPoolOrder());
         }
         return isValid;
+    }
+
+    // Don't ask why this is needed. Silent's card pool is reversed on the Neow Transforms, everyone else's is fine
+    private boolean shouldReverseCardPoolOrder(){
+        return AbstractDungeon.player.chosenClass == AbstractPlayer.PlayerClass.THE_SILENT;
     }
 }

--- a/src/main/java/FilterTheSpire/simulators/CardTransformSimulator.java
+++ b/src/main/java/FilterTheSpire/simulators/CardTransformSimulator.java
@@ -1,7 +1,6 @@
 package FilterTheSpire.simulators;
 
 import FilterTheSpire.factory.CharacterPoolFactory;
-import FilterTheSpire.utils.SeedHelper;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.random.Random;
 
@@ -19,15 +18,6 @@ public class CardTransformSimulator {
 
     private CardTransformSimulator(){
 
-    }
-
-    public boolean isValid(long seed, HashMap<String, Integer> searchCards, int transformCount) {
-        Random cardRng = SeedHelper.getNewRNG(seed, SeedHelper.RNGType.CARDRANDOM);
-        return isValid(cardRng, searchCards, transformCount);
-    }
-
-    public boolean isValid(Random cardRng, HashMap<String, Integer> searchCards, int transformCount) {
-        return isValid(cardRng, searchCards, transformCount, false);
     }
 
     public boolean isValid(Random cardRng, HashMap<String, Integer> searchCards, int transformCount, boolean shouldReverseCardOrder) {

--- a/src/main/java/FilterTheSpire/simulators/CardTransformSimulator.java
+++ b/src/main/java/FilterTheSpire/simulators/CardTransformSimulator.java
@@ -20,8 +20,8 @@ public class CardTransformSimulator {
 
     }
 
-    public boolean isValid(Random cardRng, HashMap<String, Integer> searchCards, int transformCount, boolean shouldReverseCardOrder) {
-        List<String> cardPool = CharacterPoolFactory.getCardPool(AbstractDungeon.player.chosenClass, shouldReverseCardOrder);
+    public boolean isValid(Random cardRng, HashMap<String, Integer> searchCards, int transformCount, boolean shouldReverseCommonCardPool) {
+        List<String> cardPool = CharacterPoolFactory.getCardPool(AbstractDungeon.player.chosenClass, shouldReverseCommonCardPool);
         ArrayList<String> results = new ArrayList<>();
 
         Set<String> cardList = searchCards.keySet();

--- a/src/main/java/FilterTheSpire/simulators/CardTransformSimulator.java
+++ b/src/main/java/FilterTheSpire/simulators/CardTransformSimulator.java
@@ -27,7 +27,11 @@ public class CardTransformSimulator {
     }
 
     public boolean isValid(Random cardRng, HashMap<String, Integer> searchCards, int transformCount) {
-        List<String> cardPool = CharacterPoolFactory.getCardPool(AbstractDungeon.player.chosenClass);
+        return isValid(cardRng, searchCards, transformCount, false);
+    }
+
+    public boolean isValid(Random cardRng, HashMap<String, Integer> searchCards, int transformCount, boolean shouldReverseCardOrder) {
+        List<String> cardPool = CharacterPoolFactory.getCardPool(AbstractDungeon.player.chosenClass, shouldReverseCardOrder);
         ArrayList<String> results = new ArrayList<>();
 
         Set<String> cardList = searchCards.keySet();

--- a/src/main/java/FilterTheSpire/utils/CardPoolHelper.java
+++ b/src/main/java/FilterTheSpire/utils/CardPoolHelper.java
@@ -5,9 +5,11 @@ import com.megacrit.cardcrawl.helpers.ModHelper;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class CardPoolHelper {
-    public static ArrayList<String> getOrderedCardPoolForColors(ArrayList<CharacterPool> colors){
+    public static ArrayList<String> getOrderedCardPoolForColors(ArrayList<CharacterPool> colors, boolean shouldReverseCardOrder){
         ArrayList<AbstractCard.CardRarity> cardRarities = new ArrayList<>();
         cardRarities.add(AbstractCard.CardRarity.COMMON);
         cardRarities.add(AbstractCard.CardRarity.UNCOMMON);
@@ -20,19 +22,21 @@ public class CardPoolHelper {
                 CharacterPool color = colors.get(i);
                 switch (rarity){
                     case COMMON:
-                        cardPool.addAll(color.commonCardPool);
+                        cardPool.addAll(getCardsInReversedOrderIfNeeded(color.commonCardPool, shouldReverseCardOrder));
                         break;
                     case UNCOMMON:
-                        cardPool.addAll(color.uncommonCardPool);
+                        cardPool.addAll(getCardsInReversedOrderIfNeeded(color.uncommonCardPool, shouldReverseCardOrder));
 
                         if (i == (colors.size() - 1) && hasColorlessEnabled) {
-                            cardPool.addAll(getUncommonColorlessCards());
+                            cardPool.addAll(getCardsInReversedOrderIfNeeded(getUncommonColorlessCards(), shouldReverseCardOrder));
                         }
                         break;
                     case RARE:
-                        cardPool.addAll(color.rareCardPool);
+                        cardPool.addAll(getCardsInReversedOrderIfNeeded(color.rareCardPool, shouldReverseCardOrder));
 
                         if (i == (colors.size() - 1) && hasColorlessEnabled) {
+                            cardPool.addAll(getCardsInReversedOrderIfNeeded(getRareColorlessCards(), shouldReverseCardOrder));
+
                             cardPool.addAll(getRareColorlessCards());
                         }
                         break;
@@ -40,6 +44,14 @@ public class CardPoolHelper {
             }
         }
         return cardPool;
+    }
+
+    private static List<String> getCardsInReversedOrderIfNeeded(List<String> cards, boolean shouldReverseCardOrder){
+        ArrayList<String> resultingCardList = new ArrayList<>(cards);
+        if (shouldReverseCardOrder) {
+            Collections.reverse(resultingCardList);
+        }
+        return resultingCardList;
     }
 
     private static ArrayList<String> getUncommonColorlessCards(){

--- a/src/main/java/FilterTheSpire/utils/CardPoolHelper.java
+++ b/src/main/java/FilterTheSpire/utils/CardPoolHelper.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class CardPoolHelper {
-    public static ArrayList<String> getOrderedCardPoolForColors(ArrayList<CharacterPool> colors, boolean shouldReverseCardOrder){
+    public static ArrayList<String> getOrderedCardPoolForColors(ArrayList<CharacterPool> colors, boolean shouldReverseCommonCardPool){
         ArrayList<AbstractCard.CardRarity> cardRarities = new ArrayList<>();
         cardRarities.add(AbstractCard.CardRarity.COMMON);
         cardRarities.add(AbstractCard.CardRarity.UNCOMMON);
@@ -22,21 +22,19 @@ public class CardPoolHelper {
                 CharacterPool color = colors.get(i);
                 switch (rarity){
                     case COMMON:
-                        cardPool.addAll(getCardsInReversedOrderIfNeeded(color.commonCardPool, shouldReverseCardOrder));
+                        cardPool.addAll(getCardsInReversedOrderIfNeeded(color.commonCardPool, shouldReverseCommonCardPool));
                         break;
                     case UNCOMMON:
-                        cardPool.addAll(getCardsInReversedOrderIfNeeded(color.uncommonCardPool, shouldReverseCardOrder));
+                        cardPool.addAll(color.uncommonCardPool);
 
                         if (i == (colors.size() - 1) && hasColorlessEnabled) {
-                            cardPool.addAll(getCardsInReversedOrderIfNeeded(getUncommonColorlessCards(), shouldReverseCardOrder));
+                            cardPool.addAll(getUncommonColorlessCards());
                         }
                         break;
                     case RARE:
-                        cardPool.addAll(getCardsInReversedOrderIfNeeded(color.rareCardPool, shouldReverseCardOrder));
+                        cardPool.addAll(color.rareCardPool);
 
                         if (i == (colors.size() - 1) && hasColorlessEnabled) {
-                            cardPool.addAll(getCardsInReversedOrderIfNeeded(getRareColorlessCards(), shouldReverseCardOrder));
-
                             cardPool.addAll(getRareColorlessCards());
                         }
                         break;

--- a/src/main/java/FilterTheSpire/utils/CharacterPool.java
+++ b/src/main/java/FilterTheSpire/utils/CharacterPool.java
@@ -159,5 +159,5 @@ public abstract class CharacterPool {
         ));
     }
 
-    public abstract List<String> getCardPool(boolean shouldReverseCardOrder);
+    public abstract List<String> getCardPool(boolean shouldReverseCommonCardPool);
 }

--- a/src/main/java/FilterTheSpire/utils/CharacterPool.java
+++ b/src/main/java/FilterTheSpire/utils/CharacterPool.java
@@ -159,5 +159,5 @@ public abstract class CharacterPool {
         ));
     }
 
-    public abstract List<String> getCardPool();
+    public abstract List<String> getCardPool(boolean shouldReverseCardOrder);
 }

--- a/src/main/java/FilterTheSpire/utils/DefectPool.java
+++ b/src/main/java/FilterTheSpire/utils/DefectPool.java
@@ -116,7 +116,7 @@ public class DefectPool extends CharacterPool {
         shopRelicPool.add("Runic Capacitor");
     }
 
-    public List<String> getCardPool() {
+    public List<String> getCardPool(boolean shouldReverseCardOrder) {
         ArrayList<CharacterPool> colors = new ArrayList<>();
         if (ModHelper.isModEnabled("Purple Cards")) {
             colors.add(WatcherPool.getInstance());
@@ -130,6 +130,6 @@ public class DefectPool extends CharacterPool {
             colors.add(IroncladPool.getInstance());
         }
         colors.add(DefectPool.getInstance());
-        return CardPoolHelper.getOrderedCardPoolForColors(colors);
+        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder);
     }
 }

--- a/src/main/java/FilterTheSpire/utils/DefectPool.java
+++ b/src/main/java/FilterTheSpire/utils/DefectPool.java
@@ -116,7 +116,7 @@ public class DefectPool extends CharacterPool {
         shopRelicPool.add("Runic Capacitor");
     }
 
-    public List<String> getCardPool(boolean shouldReverseCardOrder) {
+    public List<String> getCardPool(boolean shouldReverseCommonCardPool) {
         ArrayList<CharacterPool> colors = new ArrayList<>();
         if (ModHelper.isModEnabled("Purple Cards")) {
             colors.add(WatcherPool.getInstance());
@@ -130,6 +130,6 @@ public class DefectPool extends CharacterPool {
             colors.add(IroncladPool.getInstance());
         }
         colors.add(DefectPool.getInstance());
-        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder);
+        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCommonCardPool);
     }
 }

--- a/src/main/java/FilterTheSpire/utils/IroncladPool.java
+++ b/src/main/java/FilterTheSpire/utils/IroncladPool.java
@@ -119,7 +119,7 @@ public class IroncladPool extends CharacterPool {
         shopRelicPool.add("Brimstone");
     }
 
-    public List<String> getCardPool() {
+    public List<String> getCardPool(boolean shouldReverseCardOrder) {
         ArrayList<CharacterPool> colors = new ArrayList<>();
         if (ModHelper.isModEnabled("Purple Cards")) {
             colors.add(WatcherPool.getInstance());
@@ -133,6 +133,6 @@ public class IroncladPool extends CharacterPool {
             colors.add(SilentPool.getInstance());
         }
         colors.add(IroncladPool.getInstance());
-        return CardPoolHelper.getOrderedCardPoolForColors(colors);
+        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder);
     }
 }

--- a/src/main/java/FilterTheSpire/utils/IroncladPool.java
+++ b/src/main/java/FilterTheSpire/utils/IroncladPool.java
@@ -119,7 +119,7 @@ public class IroncladPool extends CharacterPool {
         shopRelicPool.add("Brimstone");
     }
 
-    public List<String> getCardPool(boolean shouldReverseCardOrder) {
+    public List<String> getCardPool(boolean shouldReverseCommonCardPool) {
         ArrayList<CharacterPool> colors = new ArrayList<>();
         if (ModHelper.isModEnabled("Purple Cards")) {
             colors.add(WatcherPool.getInstance());
@@ -133,6 +133,6 @@ public class IroncladPool extends CharacterPool {
             colors.add(SilentPool.getInstance());
         }
         colors.add(IroncladPool.getInstance());
-        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder);
+        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCommonCardPool);
     }
 }

--- a/src/main/java/FilterTheSpire/utils/SilentPool.java
+++ b/src/main/java/FilterTheSpire/utils/SilentPool.java
@@ -118,7 +118,7 @@ public class SilentPool extends CharacterPool {
         shopRelicPool.add("TwistedFunnel");
     }
 
-    public List<String> getCardPool() {
+    public List<String> getCardPool(boolean shouldReverseCardOrder) {
         ArrayList<CharacterPool> colors = new ArrayList<>();
         if (ModHelper.isModEnabled("Purple Cards")) {
             colors.add(WatcherPool.getInstance());
@@ -132,6 +132,6 @@ public class SilentPool extends CharacterPool {
             colors.add(IroncladPool.getInstance());
         }
         colors.add(SilentPool.getInstance());
-        return CardPoolHelper.getOrderedCardPoolForColors(colors);
+        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder);
     }
 }

--- a/src/main/java/FilterTheSpire/utils/SilentPool.java
+++ b/src/main/java/FilterTheSpire/utils/SilentPool.java
@@ -118,7 +118,7 @@ public class SilentPool extends CharacterPool {
         shopRelicPool.add("TwistedFunnel");
     }
 
-    public List<String> getCardPool(boolean shouldReverseCardOrder) {
+    public List<String> getCardPool(boolean shouldReverseCommonCardPool) {
         ArrayList<CharacterPool> colors = new ArrayList<>();
         if (ModHelper.isModEnabled("Purple Cards")) {
             colors.add(WatcherPool.getInstance());
@@ -132,6 +132,6 @@ public class SilentPool extends CharacterPool {
             colors.add(IroncladPool.getInstance());
         }
         colors.add(SilentPool.getInstance());
-        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder);
+        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCommonCardPool);
     }
 }

--- a/src/main/java/FilterTheSpire/utils/WatcherPool.java
+++ b/src/main/java/FilterTheSpire/utils/WatcherPool.java
@@ -116,7 +116,7 @@ public class WatcherPool extends CharacterPool {
         shopRelicPool.add("Melange");
     }
 
-    public List<String> getCardPool() {
+    public List<String> getCardPool(boolean shouldReverseCardOrder) {
         ArrayList<CharacterPool> colors = new ArrayList<>();
         // for some reason she adds her own color twice
         if (ModHelper.isModEnabled("Purple Cards")) {
@@ -135,6 +135,6 @@ public class WatcherPool extends CharacterPool {
             colors.add(IroncladPool.getInstance());
         }
         colors.add(WatcherPool.getInstance());
-        return CardPoolHelper.getOrderedCardPoolForColors(colors);
+        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder);
     }
 }

--- a/src/main/java/FilterTheSpire/utils/WatcherPool.java
+++ b/src/main/java/FilterTheSpire/utils/WatcherPool.java
@@ -116,7 +116,7 @@ public class WatcherPool extends CharacterPool {
         shopRelicPool.add("Melange");
     }
 
-    public List<String> getCardPool(boolean shouldReverseCardOrder) {
+    public List<String> getCardPool(boolean shouldReverseCommonCardPool) {
         ArrayList<CharacterPool> colors = new ArrayList<>();
         // for some reason she adds her own color twice
         if (ModHelper.isModEnabled("Purple Cards")) {
@@ -135,6 +135,6 @@ public class WatcherPool extends CharacterPool {
             colors.add(IroncladPool.getInstance());
         }
         colors.add(WatcherPool.getInstance());
-        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCardOrder);
+        return CardPoolHelper.getOrderedCardPoolForColors(colors, shouldReverseCommonCardPool);
     }
 }


### PR DESCRIPTION
This is the dumbest thing. In some cases where the game does card transforms, the Common card pool is reversed, but ONLY the common card pool. The other rarities stay consistent in every transform it seems like, but commons can be reversed and at this point I'm not actually sure which is the "correct" deterministic order.

This made me want to create more tests for this, so we can properly test each of the following transforms:

- Each class
- each card rarity
- each custom mod (Diverse, colorless card)
- each transform method (Pandoras Box, Neow bonuses, and Astrolabe)